### PR TITLE
BlocklyJam.commandを修正した。

### DIFF
--- a/BlocklyJam.command
+++ b/BlocklyJam.command
@@ -1,2 +1,3 @@
-cd $0
+cd `dirname $0`
+cd ..
 nwjs.app/Contents/MacOS/nwjs app


### PR DESCRIPTION
自分の実行環境では、`nwjs-sdk-v0.28.1-osx-x64 2`というディレクトリ上で実行していたため、`cd nwjs-sdk-v0.28.1-osx-x64`が実行されてしまい、たまたま起動できてしまっていた。